### PR TITLE
disable certificate check for HTTPS

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -106,6 +106,9 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
 * **cl_http_max_connections**: Maximum number of parallel downloads. Set
   to `4` by default. A higher number may help with slow servers.
 
+* **cl_http_verifypeer**: SSL certificate validation. Set to `1`
+  by default, set to `0` to disable.
+
 * **cl_http_proxy**: Proxy to use, empty by default.
 
 * **cl_http_show_dw_progress**: Show a HTTP download progress bar.

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -568,7 +568,8 @@ CL_InitLocal(void)
 	cl_vwep = Cvar_Get("cl_vwep", "1", CVAR_ARCHIVE);
 
 #ifdef USE_CURL
-	cl_http_proxy = Cvar_Get("cl_http_proxy", "", 0);
+	cl_http_verifypeer = Cvar_Get("cl_http_verifypeer", "1", CVAR_ARCHIVE);
+	cl_http_proxy = Cvar_Get("cl_http_proxy", "", CVAR_ARCHIVE);
 	cl_http_filelists = Cvar_Get("cl_http_filelists", "1", 0);
 	cl_http_downloads = Cvar_Get("cl_http_downloads", "1", CVAR_ARCHIVE);
 	cl_http_max_connections = Cvar_Get("cl_http_max_connections", "4", 0);

--- a/src/client/curl/download.c
+++ b/src/client/curl/download.c
@@ -33,6 +33,7 @@
 
 cvar_t *cl_http_downloads;
 cvar_t *cl_http_filelists;
+cvar_t *cl_http_verifypeer;
 cvar_t *cl_http_proxy;
 cvar_t *cl_http_max_connections;
 cvar_t *cl_http_show_dw_progress;
@@ -278,7 +279,6 @@ static void CL_StartHTTPDownload (dlqueue_t *entry, dlhandle_t *dl)
 
 	Com_sprintf(dl->URL, sizeof(dl->URL), "%s%s", cls.downloadServer, escapedFilePath);
 
-	qcurl_easy_setopt(dl->curl, CURLOPT_SSL_VERIFYPEER, 0);
 	qcurl_easy_setopt(dl->curl, CURLOPT_ENCODING, "");
 	qcurl_easy_setopt(dl->curl, CURLOPT_WRITEDATA, dl);
 
@@ -291,6 +291,8 @@ static void CL_StartHTTPDownload (dlqueue_t *entry, dlhandle_t *dl)
 		qcurl_easy_setopt(dl->curl, CURLOPT_WRITEFUNCTION, CL_HTTP_Recv);
 	}
 
+	qcurl_easy_setopt(dl->curl, CURLOPT_SSL_VERIFYPEER, (long)cl_http_verifypeer->value);
+	qcurl_easy_setopt(dl->curl, CURLOPT_PROXY_SSL_VERIFYPEER, (long)cl_http_verifypeer->value);
 	qcurl_easy_setopt(dl->curl, CURLOPT_PROXY, cl_http_proxy->string);
 	qcurl_easy_setopt(dl->curl, CURLOPT_LOW_SPEED_TIME, (long)cl_http_bw_limit_tmout->value);
 	qcurl_easy_setopt(dl->curl, CURLOPT_LOW_SPEED_LIMIT, (long)cl_http_bw_limit_rate->value);

--- a/src/client/curl/download.c
+++ b/src/client/curl/download.c
@@ -278,6 +278,7 @@ static void CL_StartHTTPDownload (dlqueue_t *entry, dlhandle_t *dl)
 
 	Com_sprintf(dl->URL, sizeof(dl->URL), "%s%s", cls.downloadServer, escapedFilePath);
 
+	qcurl_easy_setopt(dl->curl, CURLOPT_SSL_VERIFYPEER, 0);
 	qcurl_easy_setopt(dl->curl, CURLOPT_ENCODING, "");
 	qcurl_easy_setopt(dl->curl, CURLOPT_WRITEDATA, dl);
 

--- a/src/client/curl/header/download.h
+++ b/src/client/curl/header/download.h
@@ -72,6 +72,7 @@ extern dlquirks_t dlquirks;
 
 extern cvar_t *cl_http_downloads;
 extern cvar_t *cl_http_filelists;
+extern cvar_t *cl_http_verifypeer;
 extern cvar_t *cl_http_proxy;
 extern cvar_t *cl_http_max_connections;
 extern cvar_t *cl_http_show_dw_progress;


### PR DESCRIPTION
disable SSL certificate check - to allow download from servers with self-signed cert, or when some certs are missing from system certificate store that CURL uses